### PR TITLE
Feat/admin user delete a tweet

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -3,8 +3,7 @@ const { Tweet, User } = require('../models')
 const adminController = {
   deleteTweet: async (req, res) => {
     try {
-      const tweet = await Tweet.findByPk(req.params.id);
-      tweet.destroy();
+      await Tweet.destroy({where: {id: Number(req.params.id)}});
       return res.status(200).json({ status: 'success', message: '成功刪除貼文' })
     } catch (error) {
       console.log(error)

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,0 +1,16 @@
+const { Tweet, User } = require('../models')
+
+const adminController = {
+  deleteTweet: async (req, res) => {
+    try {
+      const tweet = await Tweet.findByPk(req.params.id);
+      tweet.destroy();
+      return res.status(200).json({ status: 'success', message: '成功刪除貼文' })
+    } catch (error) {
+      console.log(error)
+      return res.status(500).json({ status: 'error', message: 'Server error' })
+    }
+  }
+}
+
+module.exports = adminController

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,7 @@ const tweetController = require('../controllers/tweetController')
 const followController = require('../controllers/followController')
 const passport = require('../config/passport')
 const helpers = require('../_helpers')
+const adminController = require('../controllers/adminController')
 
 // use helpers.getUser(req) to replace req.user
 // 驗前台是user身分
@@ -37,6 +38,7 @@ const authenticated = (req, res, next) => {
 }
 
 module.exports = (app) => {
+
   // JWT signin & signup
   app.post('/api/users', userController.signUp)
   app.post('/api/users/signin', userController.signIn)
@@ -55,4 +57,8 @@ module.exports = (app) => {
 
   // followship
   app.get('/api/followships/top', authenticated, authenticatedUser, followController.getTopUser)
+
+  //admin
+  app.delete('/api/admin/tweets/:id', authenticated, authenticatedAdmin, adminController.deleteTweet)
+
 }

--- a/test/requests/admin.spec.js
+++ b/test/requests/admin.spec.js
@@ -77,7 +77,7 @@ describe('# admin requests', () => {
         // 在測試資料庫中，新增 mock 資料
         await db.User.create({ account: 'User1', name: 'User1', email: 'User1', password: 'User1', role: 'admin' })
         await db.User.create({ account: 'User2', name: 'User2', email: 'User2', password: 'User2' })
-        await db.Tweet.create({ id: 1, UserId: 1, description: 'User1 的 description' })
+        await db.Tweet.create({ UserId: 1, description: 'User1 的 description' })
       })
 
       // DELETE /admin/tweets/:id - 刪除使用者的推文

--- a/test/requests/admin.spec.js
+++ b/test/requests/admin.spec.js
@@ -77,7 +77,7 @@ describe('# admin requests', () => {
         // 在測試資料庫中，新增 mock 資料
         await db.User.create({ account: 'User1', name: 'User1', email: 'User1', password: 'User1', role: 'admin' })
         await db.User.create({ account: 'User2', name: 'User2', email: 'User2', password: 'User2' })
-        await db.Tweet.create({ id: 1UserId: 1, description: 'User1 的 description' })
+        await db.Tweet.create({ id: 1, UserId: 1, description: 'User1 的 description' })
       })
 
       // DELETE /admin/tweets/:id - 刪除使用者的推文

--- a/test/requests/admin.spec.js
+++ b/test/requests/admin.spec.js
@@ -16,20 +16,20 @@ describe('# admin requests', () => {
   context('# GET ', () => {
 
     describe(' /api/admin/users', () => {
-      before(async() => {
+      before(async () => {
         // 清除 User table 的測試資料庫資料
-        await db.User.destroy({where: {},truncate: true})
+        await db.User.destroy({ where: {}, truncate: true })
         // 模擬登入資料
-        const rootUser = await db.User.create({name: 'root'});this.authenticate =  sinon.stub(passport,"authenticate").callsFake((strategy, options, callback) => {            
-          callback(null, {...rootUser}, null);
-          return (req,res,next)=>{};
+        const rootUser = await db.User.create({ name: 'root' }); this.authenticate = sinon.stub(passport, "authenticate").callsFake((strategy, options, callback) => {
+          callback(null, { ...rootUser }, null);
+          return (req, res, next) => { };
         });
         this.getUser = sinon.stub(
-            helpers, 'getUser'
-        ).returns({id: 1, Followings: [], role: 'admin'});
+          helpers, 'getUser'
+        ).returns({ id: 1, Followings: [], role: 'admin' });
         // 在測試資料庫中，新增 mock 資料
-        await db.User.create({account: 'User1', name: 'User1', email: 'User1', password: 'User1', role: 'admin'})
-        await db.User.create({account: 'User2', name: 'User2', email: 'User2', password: 'User2'})
+        await db.User.create({ account: 'User1', name: 'User1', email: 'User1', password: 'User1', role: 'admin' })
+        await db.User.create({ account: 'User2', name: 'User2', email: 'User2', password: 'User2' })
       })
 
       // GET /admin/users - 看見站內所有的使用者
@@ -38,7 +38,7 @@ describe('# admin requests', () => {
           .get('/api/admin/users')
           .set('Accept', 'application/json')
           .expect(200)
-          .end(function(err, res) {
+          .end(function (err, res) {
             if (err) return done(err);
             // 檢查回傳資料是否是陣列類型
             expect(res.body).to.be.an('array');
@@ -52,7 +52,7 @@ describe('# admin requests', () => {
         // 清除登入及測試資料庫資料
         this.authenticate.restore();
         this.getUser.restore();
-        await db.User.destroy({where: {},truncate: true})
+        await db.User.destroy({ where: {}, truncate: true })
       })
 
     });
@@ -62,22 +62,22 @@ describe('# admin requests', () => {
   context('# DELETE ', () => {
 
     describe(' /api/admin/tweets/:id', () => {
-      before(async() => {
+      before(async () => {
         // 清除 User, Tweet table 的測試資料庫資料
-        await db.User.destroy({where: {},truncate: true})
-        await db.Tweet.destroy({where: {},truncate: true})
+        await db.User.destroy({ where: {}, truncate: true })
+        await db.Tweet.destroy({ where: {}, truncate: true })
         // 模擬登入資料
-        const rootUser = await db.User.create({name: 'root'});this.authenticate =  sinon.stub(passport,"authenticate").callsFake((strategy, options, callback) => {            
-          callback(null, {...rootUser}, null);
-          return (req,res,next)=>{};
+        const rootUser = await db.User.create({ name: 'root' }); this.authenticate = sinon.stub(passport, "authenticate").callsFake((strategy, options, callback) => {
+          callback(null, { ...rootUser }, null);
+          return (req, res, next) => { };
         });
         this.getUser = sinon.stub(
-            helpers, 'getUser'
-        ).returns({id: 1, Followings: [], role: 'admin'});
+          helpers, 'getUser'
+        ).returns({ id: 1, Followings: [], role: 'admin' });
         // 在測試資料庫中，新增 mock 資料
-        await db.User.create({account: 'User1', name: 'User1', email: 'User1', password: 'User1', role: 'admin'})
-        await db.User.create({account: 'User2', name: 'User2', email: 'User2', password: 'User2'})        
-        await db.Tweet.create({UserId: 1, description: 'User1 的 description'})
+        await db.User.create({ account: 'User1', name: 'User1', email: 'User1', password: 'User1', role: 'admin' })
+        await db.User.create({ account: 'User2', name: 'User2', email: 'User2', password: 'User2' })
+        await db.Tweet.create({ id: 1UserId: 1, description: 'User1 的 description' })
       })
 
       // DELETE /admin/tweets/:id - 刪除使用者的推文
@@ -86,7 +86,7 @@ describe('# admin requests', () => {
           .delete('/api/admin/tweets/1')
           .set('Accept', 'application/json')
           .expect(200)
-          .end(function(err, res) {
+          .end(function (err, res) {
             if (err) return done(err);
             // 檢查是否 Tweet table 中的資料是空的，表示有刪除成功
             db.Tweet.findByPk(1).then(tweet => {
@@ -101,8 +101,8 @@ describe('# admin requests', () => {
         // 清除登入及測試資料庫資料
         this.authenticate.restore();
         this.getUser.restore();
-        await db.User.destroy({where: {},truncate: true})
-        await db.Tweet.destroy({where: {},truncate: true})
+        await db.User.destroy({ where: {}, truncate: true })
+        await db.Tweet.destroy({ where: {}, truncate: true })
       })
 
     });

--- a/test/requests/user.spec.js
+++ b/test/requests/user.spec.js
@@ -44,7 +44,7 @@ describe('# user requests', () => {
   })
 
   context('# GET ', () => {
-    describe('GET /users/:id', () => {
+    describe.only('GET /users/:id', () => {
       before(async () => {
         // 清除測試資料庫資料
         await db.User.destroy({ where: {}, truncate: true })

--- a/test/requests/user.spec.js
+++ b/test/requests/user.spec.js
@@ -54,7 +54,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => { }
+            return (req, res, next) => {}
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -108,7 +108,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => { }
+            return (req, res, next) => {}
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -161,7 +161,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => { }
+            return (req, res, next) => {}
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -220,7 +220,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => { }
+            return (req, res, next) => {}
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -280,7 +280,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => { }
+            return (req, res, next) => {}
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -339,7 +339,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => { }
+            return (req, res, next) => {}
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -399,7 +399,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => { }
+            return (req, res, next) => {}
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')

--- a/test/requests/user.spec.js
+++ b/test/requests/user.spec.js
@@ -44,7 +44,7 @@ describe('# user requests', () => {
   })
 
   context('# GET ', () => {
-    describe.only('GET /users/:id', () => {
+    describe('GET /users/:id', () => {
       before(async () => {
         // 清除測試資料庫資料
         await db.User.destroy({ where: {}, truncate: true })
@@ -54,7 +54,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => {}
+            return (req, res, next) => { }
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -108,7 +108,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => {}
+            return (req, res, next) => { }
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -161,7 +161,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => {}
+            return (req, res, next) => { }
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -220,7 +220,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => {}
+            return (req, res, next) => { }
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -280,7 +280,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => {}
+            return (req, res, next) => { }
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -339,7 +339,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => {}
+            return (req, res, next) => { }
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')
@@ -399,7 +399,7 @@ describe('# user requests', () => {
           .stub(passport, 'authenticate')
           .callsFake((strategy, options, callback) => {
             callback(null, { ...rootUser }, null)
-            return (req, res, next) => {}
+            return (req, res, next) => { }
           })
         this.getUser = sinon
           .stub(helpers, 'getUser')


### PR DESCRIPTION
- admin user 可以刪除一則貼文
- postman
![image](https://user-images.githubusercontent.com/23078636/144717248-c4de4b98-f9a5-4677-acb0-9e30436af1b1.png)
- 在Replies and Likes table手動增加紀錄，刪除tweet的時候會一起刪除這個record
- 我發現tweet跟user沒有關聯是沒關係的，因為目前唯一功能是刪除tweet，action這個動作的時候並不需要去動到user table，只需要cascade delete from reply and like table。
- 這個我有先改測試檔，並且在這裡發問：https://lighthouse.alphacamp.co/courses/80/units/19659。可以先review之後看AC如何回覆再看是否有其他解決方式
![image](https://user-images.githubusercontent.com/23078636/144717448-4f5a3788-d03f-4913-bb08-ef56556f9469.png)